### PR TITLE
Funcionalidad para las instrucciones de Load y Store_Actualizado

### DIFF
--- a/app/src/app/Shared/Services/Translator/translator.service.ts
+++ b/app/src/app/Shared/Services/Translator/translator.service.ts
@@ -3,7 +3,9 @@ import { Injectable } from '@angular/core';
 @Injectable({
   providedIn: 'root'
 })
+
 export class TranslatorService {
+
 
   operationToFunctionCode(op: string): string {
     const functCodes: { [key: string]: string } = {
@@ -12,6 +14,20 @@ export class TranslatorService {
       'and': '100100',
       'or': '100101',
       'slt': '101010',
+      'addu': '100001', // Operaciones Agregadas
+      'div': '011010',
+      'divu': '011011',
+      'mult': '011000',
+      'multu': '011001',
+      'nor': '100111',
+      'sll': '000000',
+      'sllv': '000100',
+      'sra': '000011',
+      'srav': '000111',
+      'srl': '000010',
+      'srlv': '000110',
+      'subu': '100011',
+      'xor': '100110',
     };
     return functCodes[op] || 'unknown';
   }
@@ -19,8 +35,12 @@ export class TranslatorService {
   convertOpCodeNameToCode(opcodeName: string): string {
     const opcodeMap: { [key: string]: string } = {
       "add": "000000", "sub": "000000", "slt": "000000", "and": "000000", "or": "000000",
-      "addi": "001000", "lw": "100011", "sw": "101011",
-      "beq": "000100", "bne": "000101", "j": "000010",
+      "addi": "001000", "lw": "100011", "sw": "101011", "beq": "000100", "bne": "000101",
+      "bgtz": "000111", "blez": "000110", "j": "000010", "jal": "000011", "addu": "000000",
+      "div": "000000", "divu": "000000", "mult": "000000", "multu": "000000", "nor": "000000",
+      "sll": "000000", "sllv": "000000", "sra": "000000", "srav": "000000", "srl": "000000",
+      "srlv": "000000", "subu": "000000", "xor": "000000", "addiu": "001001", "andi": "001100",
+      "ori": "001101", "xori": "001110", "jalr": "000000",
       "lb": "100000", "lbu": "100100", "lh": "100001", "lhu": "100101",
       "sb": "101000", "sh": "101001"
     };
@@ -30,7 +50,15 @@ export class TranslatorService {
   translateInstructionToHex(instruction: string): string {
     const funcMap: { [key: string]: string } = {
       "add": "100000", "sub": "100010", "slt": "101010", "and": "100100", "or": "100101",
+      "addu": "100001", "div": "011010",
+      "divu": "011011", "mult": "011000",
+      "multu": "011001", "nor": "100111",
+      "sll": "000000", "sllv": "000100",
+      "sra": "000011", "srav": "000111",
+      "srl": "000010", "srlv": "000110",
+      "subu": "100011", "xor": "100110",
     };
+
 
     const regMap: { [key: string]: string } = {
       "zero": "00000", "at": "00001", "v0": "00010", "v1": "00011",
@@ -43,51 +71,103 @@ export class TranslatorService {
       "gp": "11100", "sp": "11101", "fp": "11110", "ra": "11111"
     };
 
-    instruction = instruction.replace(/\$/g, ''); 
+    instruction = instruction.replace(/\$/g, '');
     const parts = instruction.split(' ');
 
     const opcode = this.convertOpCodeNameToCode(parts[0]);
     if (!opcode) return "Unknown Instruction";
 
     let binaryInstruction = opcode;
-    if (["add", "sub", "slt", "and", "or"].includes(parts[0])) {
-        
-        const rd = regMap[parts[1]];
-        const rs = regMap[parts[2]];
-        const rt = regMap[parts[3]];
-        if (!rd || !rs || !rt) return "Invalid Registers";
-        binaryInstruction += rs + rt + rd + "00000" + funcMap[parts[0]];
+
+    if (["add", "sub", "slt", "and", "or", "nor", "addu", "srlv", "subu", "srav", "sllv", "xor"].includes(parts[0])) {
+
+      const rd = regMap[parts[1]];
+      const rs = regMap[parts[2]];
+      const rt = regMap[parts[3]];
+      if (!rd || !rs || !rt) return "Invalid Registers";
+      binaryInstruction += rs + rt + rd + "00000" + funcMap[parts[0]];
+
+    } else if (["div", "divu", "mult", "multu"].includes(parts[0])) {
+
+      const rs = regMap[parts[1]];
+      const rt = regMap[parts[2]];
+      if (!rs || !rt) return "Invalid Registers";
+      binaryInstruction += rs + rt + "00000" + "00000" + funcMap[parts[0]];
     } else if (["lw", "sw", "lb", "lbu", "lh", "lhu", "sb", "sh"].includes(parts[0])) {
-        const rt = regMap[parts[1]];
-        const rs = regMap[parts[3].split(',')[0]];
-        const immediate = parseInt(parts[2]);
-        if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
-        binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
-    } else if (["addi"].includes(parts[0])) {
 
-        const rt = regMap[parts[1]];
-        const rs = regMap[parts[2]];
-        const immediate = parseInt(parts[3]);
-        if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
-        binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
-    } else if (["beq", "bne"].includes(parts[0])) {
+      const rt = regMap[parts[1]];
+      const rs = regMap[parts[3].split(',')[0]];
+      const immediate = parseInt(parts[2]);
+      if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
+      binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
+    } else if (["addi", "addiu", "andi", "ori", "xori"].includes(parts[0])) {
 
-        const rs = regMap[parts[1]];
-        const rt = regMap[parts[2]];
-        const label = parts[3];
-        if (!rs || !rt) return "Invalid Registers";
-        const offset = parseInt(label);
-        if (isNaN(offset)) return "Invalid Syntax";
-        binaryInstruction += rs + rt + (offset >>> 0).toString(2).padStart(16, '0');
-    } else if (["j"].includes(parts[0])) {
-        // J-type instruction
-        const address = parseInt(parts[1]);
-        if (isNaN(address)) return "Invalid Syntax";
-        binaryInstruction += (address >>> 0).toString(2).padStart(26, '0');
+      const rt = regMap[parts[1]];
+      const rs = regMap[parts[2]];
+      const immediate = parseInt(parts[3]);
+      if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
+      binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
+    } else if (["sll", "srl", "sra"].includes(parts[0])) {
+
+      const rd = regMap[parts[1]];
+      const rt = regMap[parts[2]];
+      const shamt = parseInt(parts[3]);
+      if (!rd || !rt || isNaN(shamt)) return "Invalid Syntax";
+      const shamtBin = shamt.toString(2).padStart(5, '0');
+      binaryInstruction += "00000" + rt + rd + shamtBin + funcMap[parts[0]];
+
+    } else if (["beq", "bne", "bgtz", "blez"].includes(parts[0])) {
+      const opcode = this.convertOpCodeNameToCode(parts[0]);
+      const rs = regMap[parts[1]];
+      const rt = ["beq", "bne"].includes(parts[0]) ? regMap[parts[2]] : "00000"; // for bgtz/blez, rt is 00000
+      const label = parts[parts.length - 1]; //offset
+      if (!rs || (["beq", "bne"].includes(parts[0]) && !rt)) return "Invalid Registers";
+      const offset = parseInt(label);
+      if (isNaN(offset)) return "Invalid Syntax";
+      const offsetBinary = (offset >>> 0).toString(2).padStart(16, '0');
+      const binaryInstruction = opcode + rs + rt + offsetBinary;
+      const hexInstruction = parseInt(binaryInstruction, 2).toString(16).toUpperCase().padStart(8, '0');
+
+      return hexInstruction;
+    } else if (["j", "jal"].includes(parts[0])) {
+      const address = parseInt(parts[1]);
+      if (isNaN(address)) return "Invalid Syntax";
+
+      const opcode = parts[0] === "j" ? "000010" : "000011";
+
+      binaryInstruction = opcode + (address >>> 0).toString(2).padStart(26, '0');
+    } else if (["jalr"].includes(parts[0])) {
+      // Instrucción tipo R para JALR: Opcode 000000 y Funct code 001001
+      const rs = regMap[parts[1]]; // Primer operando (registro fuente)
+      const rd = parts.length === 3 ? regMap[parts[2]] : "11111"; // $ra por defecto
+      //no usa rt
+      const rt = "00000";
+      const shamt = "00000";
+      const funct = "001001";
+      if (!rs || !rd) return "Invalid Registers";
+      const binaryInstruction = "000000" + rs + rt + rd + shamt + funct;
+      const hexInstruction = parseInt(binaryInstruction, 2).toString(16).toUpperCase().padStart(8, '0');
+
+      return hexInstruction;
+    } else if (["jr"].includes(parts[0])) {
+      const rs = regMap[parts[1]]; // Registro fuente
+
+      const rt = "00000"; // No utilizado
+      const rd = "00000"; // No utilizado
+      const shamt = "00000"; // Sin desplazamiento
+      const funct = "001000"; // Funct code para jr
+
+      if (!rs) return "Invalid Register";
+
+      const binaryInstruction = "000000" + rs + rt + rd + shamt + funct;
+
+      const hexInstruction = parseInt(binaryInstruction, 2).toString(16).toUpperCase().padStart(8, '0');
+
+      return hexInstruction;
     } else {
-        return "Unsupported Instruction";
-    }
-
+      return "Unsupported Instruction";
+    }  
+    
     // Convert binary instruction to hexadecimal
     const hexInstruction = parseInt(binaryInstruction, 2).toString(16).toUpperCase().padStart(8, '0');
     return hexInstruction;
@@ -107,7 +187,6 @@ export class TranslatorService {
     return regMap[registerBinary] || 'unknown';
   }
 
-  
   convertFunctToName(functBinary: string): string {
     const funcMap: { [key: string]: string } = {
       "100000": "add",
@@ -115,29 +194,53 @@ export class TranslatorService {
       "101010": "slt",
       "100100": "and",
       "100101": "or",
+      "001000": "jr",
+      "001001": "jalr",
+      "100001": "addu",
+      "011010": "div",
+      "011011": "divu",
+      "011000": "mult",
+      "011001": "multu",
+      "100111": "nor",
+      "000000": "sll",
+      "000100": "sllv",
+      "000011": "sra",
+      "000111": "srav",
+      "000010": "srl",
+      "000110": "srlv",
+      "100011": "subu",
+      "100110": "xor"
     };
   
     return funcMap[functBinary] || 'unknown';
   }
 
-  
   convertOpcodeToName(opcodeBinary: string): string {
     
     const opcodeMap: { [key: string]: string } = {
+
       "000000": "add",
       // @ts-ignore
+      "000000": "sub", "000000": "slt", "000000": "and", "000000": "or", "000000": "jalr", "000000": "jr", "000000": "addu", "000000": "div", "000000": "divu", "000000": "mult", "000000": "multu", "000000": "nor", "000000": "sll", "000000": "sllv", "000000": "sra", "000000": "srav", "000000": "srl", "000000": "srlv", "000000": "subu", "000000": "xor",
       "001000": "addi",
       "100011": "lw",
       "101011": "sw",
       "000100": "beq",
       "000101": "bne",
+      "000111": "bgtz",
+      "000110": "blez",
       "000010": "j",
+      "000011": "jal",
+      "001100": "andi",
+      "001101": "ori",
+      "001110": "xori",
+      "001001": "addiu",
       "100000": "lb",  
       "100100": "lbu", 
       "100001": "lh",  
       "100101": "lhu", 
       "101000": "sb",  
-      "101001": "sh"   
+      "101001": "sh"  
     };
     return opcodeMap[opcodeBinary] || 'unknown';
   }
@@ -156,88 +259,118 @@ export class TranslatorService {
 
     let mipsInstruction = opcodeMIPS + " ";
 
-    if (["add", "sub", "slt", "and", "or"].includes(opcodeMIPS)) {
-      //R-type instruction
-        const func = binaryInstruction.slice(26, 32);
-        console.log("Instruction func ", func);
+    if (["add", "sub", "slt", "and", "or", "jr", "jalr", "addu", "subu", "xor", "nor", "sll", "srl", "mult", "div", "sra", "srav", "srlv", "divu", "multu", "sllv"].includes(opcodeMIPS)) {
+      // Instrucción R-type
+      const func = binaryInstruction.slice(26, 32);
+      const funcMIPS = this.convertFunctToName(func);
+      
+      if (!funcMIPS) return "Unknown Instruction (function)";
+      
+      const rs = this.convertRegisterToName(binaryInstruction.slice(6, 11));
+      const rt = this.convertRegisterToName(binaryInstruction.slice(11, 16));
+      const rd = this.convertRegisterToName(binaryInstruction.slice(16, 21));
+      
+      // Para instrucciones comunes como add, sub, slt, etc.
+      if (["add", "sub", "slt", "and", "or", "addu", "subu", "xor", "nor", "srlv", "sllv", "srav"].includes(funcMIPS)) {
+          mipsInstruction = funcMIPS + " " + rd + " " + rs + " " + rt;
+      }
+      
+      // Para JR (funct code = 001000)
+      else if (funcMIPS === "jr") {
+          mipsInstruction = "jr " + rs;
+      }
+      
+      // Para JALR (funct code = 001001)
+      else if (funcMIPS === "jalr") {
+          mipsInstruction = "jalr " + rs + " " + rd ;
+      }
 
-        const funcMIPS = this.convertFunctToName(func);
-        console.log('Func:', func, 'Func MIPS:', funcMIPS);
+      // Para instrucciones de desplazamiento
+      else if (["sll", "srl", "sra"].includes(funcMIPS)) {
+        const shamt = parseInt(binaryInstruction.slice(21, 26),2); //los bits de shamt
+        mipsInstruction = funcMIPS + " " + rd + " " + rt + " " + shamt;
+      }
 
-        if (!funcMIPS) return "Unknown Instruction (function)";
-        mipsInstruction = funcMIPS + " ";
-        const rs = this.convertRegisterToName(binaryInstruction.slice(6, 11));
-        const rt = this.convertRegisterToName(binaryInstruction.slice(11, 16));
-        const rd = this.convertRegisterToName(binaryInstruction.slice(16, 21));
-        console.log('Registers:', { rs, rt, rd });
-        if (!rs || !rt || !rd) return "Invalid Registers";
-        mipsInstruction += rd + " " + rs + " " + rt;
+      // Para mult y div
+      else if (["mult", "div", "multu", "divu"].includes(funcMIPS)) {
+        mipsInstruction = funcMIPS + " " + rs + " " + rt;
+      }
+
+
     } else if (["lw", "sw", "lb", "lbu", "lh", "lhu", "sb", "sh"].includes(opcodeMIPS)) {
-        const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));
-        const rs = this.convertRegisterToName(binaryInstruction.slice(11, 16));
-        const offset = binaryInstruction.slice(16, 32);
-        if (!rt || !rs || isNaN(parseInt(offset, 2))) return "Invalid Syntax";
-        mipsInstruction += rs + " " + rt + " " + parseInt(offset, 2);
-    } else if (["addi"].includes(opcodeMIPS)) {
-        const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));
-        const rs = this.convertRegisterToName(binaryInstruction.slice(11, 16));
-        const immediate = this.binaryToHex(binaryInstruction.slice(16, 32));
-        if (!rt || !rs || !immediate) return "Invalid Syntax";
-        mipsInstruction += rs + " " + rt + " " + immediate;
-    } else if (["beq", "bne"].includes(opcodeMIPS)) {
-        const rs = this.convertRegisterToName(binaryInstruction.slice(6, 11));
-        const rt = this.convertRegisterToName(binaryInstruction.slice(11, 16));
-        const offset = parseInt(binaryInstruction.slice(16, 32), 2);
-        if (!rs || !rt || isNaN(offset)) return "Invalid Syntax";
-        mipsInstruction += rs + " " + rt + " " + offset;
-    } else if (["j"].includes(opcodeMIPS)) {
-        const address = parseInt(binaryInstruction.slice(6, 32), 2);
-        if (isNaN(address)) return "Invalid Syntax";
-        mipsInstruction += address;
-    } else {
-        return "Unsupported Instruction";
-    }
+      const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));
+      const rs = this.convertRegisterToName(binaryInstruction.slice(11, 16));
+      const offset = binaryInstruction.slice(16, 32);
+      if (!rt || !rs || isNaN(parseInt(offset, 2))) return "Invalid Syntax";
+      mipsInstruction += rs + " " + rt + " " + parseInt(offset, 2);
 
-    return mipsInstruction;
+      //Instruccion Tipo I
+  } else if (["addi", "addiu", "andi", "ori", "xori"].includes(opcodeMIPS)) {
+      const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));      
+      const rs = this.convertRegisterToName(binaryInstruction.slice(11, 16));
+      const immediate = this.binaryToHex(binaryInstruction.slice(16, 32));
+      if (!rt || !rs || !immediate) return "Invalid Syntax";
+      mipsInstruction += rs + " " + rt + " " + immediate;
+  } else if (["beq", "bne", "bgtz", "blez"].includes(opcodeMIPS)) {
+    const rs = this.convertRegisterToName(binaryInstruction.slice(6, 11));
+    const rt = ["beq", "bne"].includes(opcodeMIPS) ? this.convertRegisterToName(binaryInstruction.slice(11, 16)) : "00000";
+    const offset = parseInt(binaryInstruction.slice(16, 32), 2);
+    if (!rs || isNaN(offset)) return "Invalid Registers or Syntax";
+
+    if (opcodeMIPS === "bgtz" || opcodeMIPS === "blez") {
+      mipsInstruction += rs + " " + offset;
+    } else {
+      mipsInstruction += rs + " " + rt + " " + offset;
+    }
+  } else if (["j", "jal"].includes(opcodeMIPS)) {
+    const address = parseInt(binaryInstruction.slice(6, 32), 2);
+    if (isNaN(address)) return "Invalid Syntax";
+    mipsInstruction += address;
+  } else {
+    return "Unsupported Instruction";
   }
+
+  return mipsInstruction;
+}
 
   // Utilidades
   binaryToHex(binaryString: string): string {
     // Pad the binary string with leading zeros to ensure it's a multiple of 4
     while (binaryString.length % 4 !== 0) {
-        binaryString = '0' + binaryString;
+      binaryString = '0' + binaryString;
     }
+
     // Initialize an empty string to store the hexadecimal representation
     let hexString = '';
 
     // Convert each group of 4 bits to its hexadecimal equivalent
     for (let i = 0; i < binaryString.length; i += 4) {
-        const binaryChunk = binaryString.substring(i, i + 4); 
-        const hexDigit = parseInt(binaryChunk, 2).toString(16);
-        hexString += hexDigit;
+      const binaryChunk = binaryString.substring(i, i + 4); // Get a chunk of 4 bits
+      const hexDigit = parseInt(binaryChunk, 2).toString(16); // Convert the chunk to hexadecimal
+      hexString += hexDigit; // Append the hexadecimal digit to the result
     }
+
     // Return the hexadecimal representation
-    return "0x" + hexString.toUpperCase();
+    return "0x" + hexString.toUpperCase(); // Convert to uppercase for consistency
   }
 
   hexToBinary(hex: string): string {
     let binary = '';
     for (let i = 0; i < hex.length; i++) {
-        let bin = parseInt(hex[i], 16).toString(2);
-        binary += bin.padStart(4, '0');
+      let bin = parseInt(hex[i], 16).toString(2);
+      binary += bin.padStart(4, '0');
     }
     return binary;
   }
-
   sum(a: number, b: number): number {
     return a + b;
   }
 
-  // Translate each hexadecimal instruction to MIPS
   translateHextoMIPS(textInput: string): string {
     const instructions: string[] = textInput.trim().split('\n');
+    // Translate each hexadecimal instruction to MIPS
     const translatedInstructions: string[] = instructions.map(instruction => {
-        return this.translateInstructionToMIPS(instruction.trim());
+      return this.translateInstructionToMIPS(instruction.trim());
     });
 
     // Join the translated instructions with a newline character
@@ -246,12 +379,13 @@ export class TranslatorService {
     // Set the value of the input textarea to the formatted instructions
     return formattedInstructions;
   }
-  
-  // Translate each MIPS instruction to hexadecimal
+
   translateMIPStoHex(textInput: string): string {
     const instructions: string[] = textInput.trim().split('\n');
+
+    // Translate each MIPS instruction to hexadecimal
     const translatedInstructions: string[] = instructions.map(instruction => {
-        return this.translateInstructionToHex(instruction.trim());
+      return this.translateInstructionToHex(instruction.trim());
     });
 
     // Join the translated instructions with a newline character
@@ -260,4 +394,7 @@ export class TranslatorService {
     // Set the value of the inputHex textarea to the formatted instructions
     return formattedInstructions;
   }
+
+
+
 }

--- a/app/src/app/Shared/Services/Translator/translator.service.ts
+++ b/app/src/app/Shared/Services/Translator/translator.service.ts
@@ -12,20 +12,6 @@ export class TranslatorService {
       'and': '100100',
       'or': '100101',
       'slt': '101010',
-      'addu': '100001', // Operaciones Agregadas
-      'div': '011010',
-      'divu': '011011',
-      'mult': '011000',
-      'multu': '011001',
-      'nor': '100111',
-      'sll': '000000',
-      'sllv': '000100',
-      'sra': '000011',
-      'srav': '000111',
-      'srl': '000010',
-      'srlv': '000110',
-      'subu': '100011',
-      'xor': '100110',
     };
     return functCodes[op] || 'unknown';
   }
@@ -33,12 +19,10 @@ export class TranslatorService {
   convertOpCodeNameToCode(opcodeName: string): string {
     const opcodeMap: { [key: string]: string } = {
       "add": "000000", "sub": "000000", "slt": "000000", "and": "000000", "or": "000000",
-      "addi": "001000", "lw": "100011", "sw": "101011", "beq": "000100", "bne": "000101",
-      "bgtz": "000111", "blez": "000110", "j": "000010", "jal": "000011", "addu": "000000",
-      "div": "000000", "divu": "000000", "mult": "000000", "multu": "000000", "nor": "000000",
-      "sll": "000000", "sllv": "000000", "sra": "000000", "srav": "000000", "srl": "000000",
-      "srlv": "000000", "subu": "000000", "xor": "000000", "addiu": "001001", "andi": "001100",
-      "ori": "001101", "xori": "001110", "jalr": "000000"
+      "addi": "001000", "lw": "100011", "sw": "101011",
+      "beq": "000100", "bne": "000101", "j": "000010",
+      "lb": "100000", "lbu": "100100", "lh": "100001", "lhu": "100101",
+      "sb": "101000", "sh": "101001"
     };
     return opcodeMap[opcodeName] || 'unknown';
   }
@@ -46,15 +30,7 @@ export class TranslatorService {
   translateInstructionToHex(instruction: string): string {
     const funcMap: { [key: string]: string } = {
       "add": "100000", "sub": "100010", "slt": "101010", "and": "100100", "or": "100101",
-      "addu": "100001", "div": "011010",
-      "divu": "011011", "mult": "011000",
-      "multu": "011001", "nor": "100111",
-      "sll": "000000", "sllv": "000100",
-      "sra": "000011", "srav": "000111",
-      "srl": "000010", "srlv": "000110",
-      "subu": "100011", "xor": "100110",
     };
-
 
     const regMap: { [key: string]: string } = {
       "zero": "00000", "at": "00001", "v0": "00010", "v1": "00011",
@@ -67,99 +43,49 @@ export class TranslatorService {
       "gp": "11100", "sp": "11101", "fp": "11110", "ra": "11111"
     };
 
-    instruction = instruction.replace(/\$/g, '');
+    instruction = instruction.replace(/\$/g, ''); 
     const parts = instruction.split(' ');
 
     const opcode = this.convertOpCodeNameToCode(parts[0]);
     if (!opcode) return "Unknown Instruction";
 
     let binaryInstruction = opcode;
-    if (["add", "sub", "slt", "and", "or", "nor", "addu", "srlv", "subu", "srav", "sllv", "xor"].includes(parts[0])) {
+    if (["add", "sub", "slt", "and", "or"].includes(parts[0])) {
+        
+        const rd = regMap[parts[1]];
+        const rs = regMap[parts[2]];
+        const rt = regMap[parts[3]];
+        if (!rd || !rs || !rt) return "Invalid Registers";
+        binaryInstruction += rs + rt + rd + "00000" + funcMap[parts[0]];
+    } else if (["lw", "sw", "lb", "lbu", "lh", "lhu", "sb", "sh"].includes(parts[0])) {
+        const rt = regMap[parts[1]];
+        const rs = regMap[parts[3].split(',')[0]];
+        const immediate = parseInt(parts[2]);
+        if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
+        binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
+    } else if (["addi"].includes(parts[0])) {
 
-      const rd = regMap[parts[1]];
-      const rs = regMap[parts[2]];
-      const rt = regMap[parts[3]];
-      if (!rd || !rs || !rt) return "Invalid Registers";
-      binaryInstruction += rs + rt + rd + "00000" + funcMap[parts[0]];
+        const rt = regMap[parts[1]];
+        const rs = regMap[parts[2]];
+        const immediate = parseInt(parts[3]);
+        if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
+        binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
+    } else if (["beq", "bne"].includes(parts[0])) {
 
-    } else if (["div", "divu", "mult", "multu"].includes(parts[0])) {
-      const rs = regMap[parts[1]];
-      const rt = regMap[parts[2]];
-      if (!rs || !rt) return "Invalid Registers";
-      binaryInstruction += rs + rt + "00000" + "00000" + funcMap[parts[0]];
-    } else if (["lw", "sw"].includes(parts[0])) {
-
-      const rt = regMap[parts[1]];
-      const rs = regMap[parts[3].split(',')[0]];
-      const immediate = parseInt(parts[2]);
-      if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
-      binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
-    } else if (["addi", "addiu", "andi", "ori", "xori"].includes(parts[0])) {
-
-      const rt = regMap[parts[1]];
-      const rs = regMap[parts[2]];
-      const immediate = parseInt(parts[3]);
-      if (!rt || !rs || isNaN(immediate)) return "Invalid Syntax";
-      binaryInstruction += rs + rt + (immediate >>> 0).toString(2).padStart(16, '0');
-    } else if (["sll", "srl", "sra"].includes(parts[0])) {
-
-      const rd = regMap[parts[1]];
-      const rt = regMap[parts[2]];
-      const shamt = parseInt(parts[3]);
-      if (!rd || !rt || isNaN(shamt)) return "Invalid Syntax";
-      const shamtBin = shamt.toString(2).padStart(5, '0');
-      binaryInstruction += "00000" + rt + rd + shamtBin + funcMap[parts[0]];
-
-    } else if (["beq", "bne", "bgtz", "blez"].includes(parts[0])) {
-      const opcode = this.convertOpCodeNameToCode(parts[0]);
-      const rs = regMap[parts[1]];
-      const rt = ["beq", "bne"].includes(parts[0]) ? regMap[parts[2]] : "00000"; // for bgtz/blez, rt is 00000
-      const label = parts[parts.length - 1]; //offset
-      if (!rs || (["beq", "bne"].includes(parts[0]) && !rt)) return "Invalid Registers";
-      const offset = parseInt(label);
-      if (isNaN(offset)) return "Invalid Syntax";
-      const offsetBinary = (offset >>> 0).toString(2).padStart(16, '0');
-      const binaryInstruction = opcode + rs + rt + offsetBinary;
-      const hexInstruction = parseInt(binaryInstruction, 2).toString(16).toUpperCase().padStart(8, '0');
-
-      return hexInstruction;
-    } else if (["j", "jal"].includes(parts[0])) {
-      const address = parseInt(parts[1]);
-      if (isNaN(address)) return "Invalid Syntax";
-
-      const opcode = parts[0] === "j" ? "000010" : "000011";
-
-      binaryInstruction = opcode + (address >>> 0).toString(2).padStart(26, '0');
-    } else if (["jalr"].includes(parts[0])) {
-      // Instrucción tipo R para JALR: Opcode 000000 y Funct code 001001
-      const rs = regMap[parts[1]]; // Primer operando (registro fuente)
-      const rd = parts.length === 3 ? regMap[parts[2]] : "11111"; // $ra por defecto
-      //no usa rt
-      const rt = "00000";
-      const shamt = "00000";
-      const funct = "001001";
-      if (!rs || !rd) return "Invalid Registers";
-      const binaryInstruction = "000000" + rs + rt + rd + shamt + funct;
-      const hexInstruction = parseInt(binaryInstruction, 2).toString(16).toUpperCase().padStart(8, '0');
-
-      return hexInstruction;
-    } else if (["jr"].includes(parts[0])) {
-      const rs = regMap[parts[1]]; // Registro fuente
-
-      const rt = "00000"; // No utilizado
-      const rd = "00000"; // No utilizado
-      const shamt = "00000"; // Sin desplazamiento
-      const funct = "001000"; // Funct code para jr
-
-      if (!rs) return "Invalid Register";
-
-      const binaryInstruction = "000000" + rs + rt + rd + shamt + funct;
-
-      const hexInstruction = parseInt(binaryInstruction, 2).toString(16).toUpperCase().padStart(8, '0');
-
-      return hexInstruction;
+        const rs = regMap[parts[1]];
+        const rt = regMap[parts[2]];
+        const label = parts[3];
+        if (!rs || !rt) return "Invalid Registers";
+        const offset = parseInt(label);
+        if (isNaN(offset)) return "Invalid Syntax";
+        binaryInstruction += rs + rt + (offset >>> 0).toString(2).padStart(16, '0');
+    } else if (["j"].includes(parts[0])) {
+        // J-type instruction
+        const address = parseInt(parts[1]);
+        if (isNaN(address)) return "Invalid Syntax";
+        binaryInstruction += (address >>> 0).toString(2).padStart(26, '0');
     } else {
-      return "Unsupported Instruction";
+        return "Unsupported Instruction";
     }
 
     // Convert binary instruction to hexadecimal
@@ -181,7 +107,7 @@ export class TranslatorService {
     return regMap[registerBinary] || 'unknown';
   }
 
-
+  
   convertFunctToName(functBinary: string): string {
     const funcMap: { [key: string]: string } = {
       "100000": "add",
@@ -189,55 +115,36 @@ export class TranslatorService {
       "101010": "slt",
       "100100": "and",
       "100101": "or",
-      "001000": "jr",
-      "001001": "jalr",
-      "100001": "addu",
-      "011010": "div",
-      "011011": "divu",
-      "011000": "mult",
-      "011001": "multu",
-      "100111": "nor",
-      "000000": "sll",
-      "000100": "sllv",
-      "000011": "sra",
-      "000111": "srav",
-      "000010": "srl",
-      "000110": "srlv",
-      "100011": "subu",
-      "100110": "xor"
     };
-
+  
     return funcMap[functBinary] || 'unknown';
   }
 
-
+  
   convertOpcodeToName(opcodeBinary: string): string {
-
+    
     const opcodeMap: { [key: string]: string } = {
-
       "000000": "add",
       // @ts-ignore
-      "000000": "sub", "000000": "slt", "000000": "and", "000000": "or", "000000": "jalr", "000000": "jr", "000000": "addu", "000000": "div", "000000": "divu", "000000": "mult", "000000": "multu", "000000": "nor", "000000": "sll", "000000": "sllv", "000000": "sra", "000000": "srav", "000000": "srl", "000000": "srlv", "000000": "subu", "000000": "xor",
       "001000": "addi",
       "100011": "lw",
       "101011": "sw",
       "000100": "beq",
       "000101": "bne",
-      "000111": "bgtz",
-      "000110": "blez",
       "000010": "j",
-      "000011": "jal",
-      "001100": "andi",
-      "001101": "ori",
-      "001110": "xori",
-      "001001": "addiu"
+      "100000": "lb",  
+      "100100": "lbu", 
+      "100001": "lh",  
+      "100101": "lhu", 
+      "101000": "sb",  
+      "101001": "sh"   
     };
     return opcodeMap[opcodeBinary] || 'unknown';
   }
 
-
+  // Función para traducir de Hex a MIPS
   translateInstructionToMIPS(hexInstruction: string): string {
-    console.log("hexInstruction", hexInstruction);
+    console.log("hexInstruction", hexInstruction);  
     const binaryInstruction = this.hexToBinary(hexInstruction);
     console.log('Binary Instruction:', binaryInstruction);
     const opcode = binaryInstruction.slice(0, 6);
@@ -249,75 +156,46 @@ export class TranslatorService {
 
     let mipsInstruction = opcodeMIPS + " ";
 
-    if (["add", "sub", "slt", "and", "or", "jr", "jalr", "addu", "subu", "xor", "nor", "sll", "srl", "mult", "div", "sra", "srav", "srlv", "divu", "multu", "sllv"].includes(opcodeMIPS)) {
-        // Instrucción R-type
+    if (["add", "sub", "slt", "and", "or"].includes(opcodeMIPS)) {
+      //R-type instruction
         const func = binaryInstruction.slice(26, 32);
+        console.log("Instruction func ", func);
+
         const funcMIPS = this.convertFunctToName(func);
-        
+        console.log('Func:', func, 'Func MIPS:', funcMIPS);
+
         if (!funcMIPS) return "Unknown Instruction (function)";
-        
+        mipsInstruction = funcMIPS + " ";
         const rs = this.convertRegisterToName(binaryInstruction.slice(6, 11));
         const rt = this.convertRegisterToName(binaryInstruction.slice(11, 16));
         const rd = this.convertRegisterToName(binaryInstruction.slice(16, 21));
-        
-        // Para instrucciones comunes como add, sub, slt, etc.
-        if (["add", "sub", "slt", "and", "or", "addu", "subu", "xor", "nor", "srlv", "sllv", "srav"].includes(funcMIPS)) {
-            mipsInstruction = funcMIPS + " " + rd + " " + rs + " " + rt;
-        }
-        
-        // Para JR (funct code = 001000)
-        else if (funcMIPS === "jr") {
-            mipsInstruction = "jr " + rs;
-        }
-        
-        // Para JALR (funct code = 001001)
-        else if (funcMIPS === "jalr") {
-            mipsInstruction = "jalr " + rs + " " + rd ;
-        }
-
-        // Para instrucciones de desplazamiento
-        else if (["sll", "srl", "sra"].includes(funcMIPS)) {
-          const shamt = parseInt(binaryInstruction.slice(21, 26),2); //los bits de shamt
-          mipsInstruction = funcMIPS + " " + rd + " " + rt + " " + shamt;
-        }
-
-        // Para mult y div
-        else if (["mult", "div", "multu", "divu"].includes(funcMIPS)) {
-          mipsInstruction = funcMIPS + " " + rs + " " + rt;
-        }
-
-
-    } else if (["lw", "sw"].includes(opcodeMIPS)) {
+        console.log('Registers:', { rs, rt, rd });
+        if (!rs || !rt || !rd) return "Invalid Registers";
+        mipsInstruction += rd + " " + rs + " " + rt;
+    } else if (["lw", "sw", "lb", "lbu", "lh", "lhu", "sb", "sh"].includes(opcodeMIPS)) {
         const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));
         const rs = this.convertRegisterToName(binaryInstruction.slice(11, 16));
         const offset = binaryInstruction.slice(16, 32);
         if (!rt || !rs || isNaN(parseInt(offset, 2))) return "Invalid Syntax";
         mipsInstruction += rs + " " + rt + " " + parseInt(offset, 2);
-
-        //Instruccion Tipo I
-    } else if (["addi", "addiu", "andi", "ori", "xori"].includes(opcodeMIPS)) {
-        const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));      
+    } else if (["addi"].includes(opcodeMIPS)) {
+        const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));
         const rs = this.convertRegisterToName(binaryInstruction.slice(11, 16));
         const immediate = this.binaryToHex(binaryInstruction.slice(16, 32));
         if (!rt || !rs || !immediate) return "Invalid Syntax";
         mipsInstruction += rs + " " + rt + " " + immediate;
-    } else if (["beq", "bne", "bgtz", "blez"].includes(opcodeMIPS)) {
-      const rs = this.convertRegisterToName(binaryInstruction.slice(6, 11));
-      const rt = ["beq", "bne"].includes(opcodeMIPS) ? this.convertRegisterToName(binaryInstruction.slice(11, 16)) : "00000";
-      const offset = parseInt(binaryInstruction.slice(16, 32), 2);
-      if (!rs || isNaN(offset)) return "Invalid Registers or Syntax";
-
-      if (opcodeMIPS === "bgtz" || opcodeMIPS === "blez") {
-        mipsInstruction += rs + " " + offset;
-      } else {
+    } else if (["beq", "bne"].includes(opcodeMIPS)) {
+        const rs = this.convertRegisterToName(binaryInstruction.slice(6, 11));
+        const rt = this.convertRegisterToName(binaryInstruction.slice(11, 16));
+        const offset = parseInt(binaryInstruction.slice(16, 32), 2);
+        if (!rs || !rt || isNaN(offset)) return "Invalid Syntax";
         mipsInstruction += rs + " " + rt + " " + offset;
-      }
-    } else if (["j", "jal"].includes(opcodeMIPS)) {
-      const address = parseInt(binaryInstruction.slice(6, 32), 2);
-      if (isNaN(address)) return "Invalid Syntax";
-      mipsInstruction += address;
+    } else if (["j"].includes(opcodeMIPS)) {
+        const address = parseInt(binaryInstruction.slice(6, 32), 2);
+        if (isNaN(address)) return "Invalid Syntax";
+        mipsInstruction += address;
     } else {
-      return "Unsupported Instruction";
+        return "Unsupported Instruction";
     }
 
     return mipsInstruction;
@@ -327,40 +205,39 @@ export class TranslatorService {
   binaryToHex(binaryString: string): string {
     // Pad the binary string with leading zeros to ensure it's a multiple of 4
     while (binaryString.length % 4 !== 0) {
-      binaryString = '0' + binaryString;
+        binaryString = '0' + binaryString;
     }
-
     // Initialize an empty string to store the hexadecimal representation
     let hexString = '';
 
     // Convert each group of 4 bits to its hexadecimal equivalent
     for (let i = 0; i < binaryString.length; i += 4) {
-      const binaryChunk = binaryString.substring(i, i + 4); // Get a chunk of 4 bits
-      const hexDigit = parseInt(binaryChunk, 2).toString(16); // Convert the chunk to hexadecimal
-      hexString += hexDigit; // Append the hexadecimal digit to the result
+        const binaryChunk = binaryString.substring(i, i + 4); 
+        const hexDigit = parseInt(binaryChunk, 2).toString(16);
+        hexString += hexDigit;
     }
-
     // Return the hexadecimal representation
-    return "0x" + hexString.toUpperCase(); // Convert to uppercase for consistency
+    return "0x" + hexString.toUpperCase();
   }
 
   hexToBinary(hex: string): string {
     let binary = '';
     for (let i = 0; i < hex.length; i++) {
-      let bin = parseInt(hex[i], 16).toString(2);
-      binary += bin.padStart(4, '0');
+        let bin = parseInt(hex[i], 16).toString(2);
+        binary += bin.padStart(4, '0');
     }
     return binary;
   }
+
   sum(a: number, b: number): number {
     return a + b;
   }
 
+  // Translate each hexadecimal instruction to MIPS
   translateHextoMIPS(textInput: string): string {
     const instructions: string[] = textInput.trim().split('\n');
-    // Translate each hexadecimal instruction to MIPS
     const translatedInstructions: string[] = instructions.map(instruction => {
-      return this.translateInstructionToMIPS(instruction.trim());
+        return this.translateInstructionToMIPS(instruction.trim());
     });
 
     // Join the translated instructions with a newline character
@@ -369,13 +246,12 @@ export class TranslatorService {
     // Set the value of the input textarea to the formatted instructions
     return formattedInstructions;
   }
-
+  
+  // Translate each MIPS instruction to hexadecimal
   translateMIPStoHex(textInput: string): string {
     const instructions: string[] = textInput.trim().split('\n');
-
-    // Translate each MIPS instruction to hexadecimal
     const translatedInstructions: string[] = instructions.map(instruction => {
-      return this.translateInstructionToHex(instruction.trim());
+        return this.translateInstructionToHex(instruction.trim());
     });
 
     // Join the translated instructions with a newline character
@@ -384,7 +260,4 @@ export class TranslatorService {
     // Set the value of the inputHex textarea to the formatted instructions
     return formattedInstructions;
   }
-
-
-
 }

--- a/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
+++ b/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
@@ -123,27 +123,27 @@ export class TableInstructionService {
       case '101011':
       case '000100':
       case '000101':
-      case '000110':
-      case '000111': 
-      case '001001':
-      case '001100':
-      case '001101':
-      case '001110':
+      case '100000': 
+      case '100100': 
+      case '100001': 
+      case '100101': 
+      case '101000': 
+      case '101001': 
         return { type: 'I', data: this.produceIInstruction(instruction) };
       case '000010':
-      case '000011':
         return { type: 'J', data: this.produceJInstruction(instruction) };
       default:
         return { type: 'unknown', data: 'Unknown instruction' };
     }
   }
+
   decodeInstruction(instruction: string) {
     let explanation = '';
     let details: any = {};
 
     // Assume `instruction` is a string like "add $t1, $t2, $t3"
     const parts = instruction.split(/\s+/);
-    const operation = parts[0]; // e.g., "add"
+    const operation = parts[0];
     console.log('operation', operation);
     switch (operation) {
       case 'add':
@@ -164,6 +164,10 @@ export class TableInstructionService {
         break;
       // Add cases for I-type and J-type instructions
       case 'lw':
+      case 'lb':
+      case 'lbu':
+      case 'lh':
+      case 'lhu':
         details = {
           operation: operation,
           rt: parts[1], // e.g., "$t1"
@@ -173,6 +177,8 @@ export class TableInstructionService {
         explanation = `This is an I-type instruction where ${details.rt} gets the value from memory at the address ${details.offset} offset from ${details.rs}.`;
         break;
       case 'sw':
+      case 'sb':
+      case 'sh':
         details = {
           operation: operation,
           rt: parts[1], // e.g., "$t1"
@@ -208,46 +214,6 @@ export class TableInstructionService {
         };
         explanation = `This is an I-type instruction where the program jumps to the target address if the values in ${details.rs} and ${details.rt} are not equal.`;
         break;
-        case 'addiu':
-          details = {
-            operation: operation,
-            rt: parts[1], // e.g., "$t1"
-            rs: parts[2], // e.g., "$t2"
-            immediate: parts[3], // e.g., "100"
-          };
-          explanation = `This is an I-type instruction where ${details.rt} get the result of adding the value in ${details.rs} and the immediate value ${details.immediate}, but without generating an overflow.`;
-          break;
-  
-        case 'andi':
-          details = {
-            operation: operation,
-            rt: parts[1], // e.g., "$t1"
-            rs: parts[2], // e.g., "$t2"
-            immediate: parts[3], // e.g., "100"
-          };
-          explanation = `This is an I-type instruction where ${details.rt} gets the result of a bitwise AND between the value in ${details.rs} and the immediate value ${details.immediate}.`;
-          break;
-  
-        case 'ori':
-          details = {
-            operation: operation,
-            rt: parts[1], // e.g., "$t1"
-            rs: parts[2], // e.g., "$t2"
-            immediate: parts[3], // e.g., "100"
-          };
-          explanation = `This is an I-type instruction where ${details.rt} gets the result of a bitwise OR between the value in ${details.rs} and the immediate value ${details.immediate}.`;
-          break;
-  
-        case 'xori':
-          details = {
-            operation: operation,
-            rt: parts[1], // e.g., "$t1"
-            rs: parts[2], // e.g., "$t2"
-            immediate: parts[3], // e.g., "100"
-          };
-          explanation = `This is an I-type instruction where ${details.rt} gets the result of a bitwise XOR between the value in ${details.rs} and the immediate value ${details.immediate}.`;
-          break;
-      
     }
     return explanation;
   }

--- a/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
+++ b/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
@@ -123,27 +123,33 @@ export class TableInstructionService {
       case '101011':
       case '000100':
       case '000101':
+      case '000110':
+      case '000111': 
+      case '001001':
+      case '001100':
+      case '001101':
+      case '001110':
       case '100000': 
       case '100100': 
       case '100001': 
       case '100101': 
       case '101000': 
-      case '101001': 
+      case '101001':   
         return { type: 'I', data: this.produceIInstruction(instruction) };
       case '000010':
+      case '000011':
         return { type: 'J', data: this.produceJInstruction(instruction) };
       default:
         return { type: 'unknown', data: 'Unknown instruction' };
     }
   }
-
   decodeInstruction(instruction: string) {
     let explanation = '';
     let details: any = {};
 
     // Assume `instruction` is a string like "add $t1, $t2, $t3"
     const parts = instruction.split(/\s+/);
-    const operation = parts[0];
+    const operation = parts[0]; // e.g., "add"
     console.log('operation', operation);
     switch (operation) {
       case 'add':
@@ -178,7 +184,7 @@ export class TableInstructionService {
         break;
       case 'sw':
       case 'sb':
-      case 'sh':
+      case 'sh':  
         details = {
           operation: operation,
           rt: parts[1], // e.g., "$t1"
@@ -214,6 +220,46 @@ export class TableInstructionService {
         };
         explanation = `This is an I-type instruction where the program jumps to the target address if the values in ${details.rs} and ${details.rt} are not equal.`;
         break;
+        case 'addiu':
+          details = {
+            operation: operation,
+            rt: parts[1], // e.g., "$t1"
+            rs: parts[2], // e.g., "$t2"
+            immediate: parts[3], // e.g., "100"
+          };
+          explanation = `This is an I-type instruction where ${details.rt} get the result of adding the value in ${details.rs} and the immediate value ${details.immediate}, but without generating an overflow.`;
+          break;
+  
+        case 'andi':
+          details = {
+            operation: operation,
+            rt: parts[1], // e.g., "$t1"
+            rs: parts[2], // e.g., "$t2"
+            immediate: parts[3], // e.g., "100"
+          };
+          explanation = `This is an I-type instruction where ${details.rt} gets the result of a bitwise AND between the value in ${details.rs} and the immediate value ${details.immediate}.`;
+          break;
+  
+        case 'ori':
+          details = {
+            operation: operation,
+            rt: parts[1], // e.g., "$t1"
+            rs: parts[2], // e.g., "$t2"
+            immediate: parts[3], // e.g., "100"
+          };
+          explanation = `This is an I-type instruction where ${details.rt} gets the result of a bitwise OR between the value in ${details.rs} and the immediate value ${details.immediate}.`;
+          break;
+  
+        case 'xori':
+          details = {
+            operation: operation,
+            rt: parts[1], // e.g., "$t1"
+            rs: parts[2], // e.g., "$t2"
+            immediate: parts[3], // e.g., "100"
+          };
+          explanation = `This is an I-type instruction where ${details.rt} gets the result of a bitwise XOR between the value in ${details.rs} and the immediate value ${details.immediate}.`;
+          break;
+      
     }
     return explanation;
   }


### PR DESCRIPTION
GPyP1_ 7: ProyectoParcial1 (Jhon Jimenez - Derek Perez)

Utilizando la última actualización del repositorio se agregó el soporte correcto para las siguientes instrucciones de Load:
- lw
- lb 
- lbu
- lh
- lhu
Y también para las siguientes instrucciones de Store:
- sw
- sb
- sh

A continuación se adjuntan las instrucciones de prueba y las capturas con el resultado que demuestran el correcto funcionamiento.

Load:
lw $t0, 0($t1) → 0x8D280000

![1](https://github.com/user-attachments/assets/631c63c2-2e5a-422f-880e-4a748e7b2fd2)
![2](https://github.com/user-attachments/assets/8036f52a-390f-4748-8e25-fb888052a3c9)

lb $t2, 8($t1) → 0x812A0008

![3](https://github.com/user-attachments/assets/02bb2c65-7ec4-4e41-80f3-eb019d01b480)
![4](https://github.com/user-attachments/assets/003793f6-ae0e-4b5d-aa3a-903901a1feba)

lbu $t0, 0($t2) → 0x91480000

![5](https://github.com/user-attachments/assets/b547f04b-3320-433d-b90b-1f483eff2f26)
![6](https://github.com/user-attachments/assets/c29ea445-cbc3-4187-b81b-7972a1b4b439)

Store:
sw $t0, 4($t1) → 0xAD280004

![7](https://github.com/user-attachments/assets/0acbb7e5-5eb6-432c-81a4-aab378352b22)
![8](https://github.com/user-attachments/assets/27d4c950-3a72-44dc-93d6-7e5e57666c2f)

sb $t2, 12($t1) → 0xA12A000C

![9](https://github.com/user-attachments/assets/ced3125b-fc55-4e19-af3b-2312bc9d0503)
![10](https://github.com/user-attachments/assets/5a891b4e-0a06-4a5b-ba6c-01abce320c06)

sh $t4, 0($t3) → 0xA56C0000

![11](https://github.com/user-attachments/assets/1d94a099-fab5-4354-ada8-964b789f9bb1)
![12](https://github.com/user-attachments/assets/52efb600-1552-4773-90bb-e43849f8ab60)

Closes #9 
