### PR TITLE
Funcionalidad completa para las instrucciones de Load y Store

### DIFF
--- a/app/src/app/Shared/Services/Translator/translator.service.ts
+++ b/app/src/app/Shared/Services/Translator/translator.service.ts
@@ -38,7 +38,8 @@ export class TranslatorService {
       "div": "000000", "divu": "000000", "mult": "000000", "multu": "000000", "nor": "000000",
       "sll": "000000", "sllv": "000000", "sra": "000000", "srav": "000000", "srl": "000000",
       "srlv": "000000", "subu": "000000", "xor": "000000", "addiu": "001001", "andi": "001100",
-      "ori": "001101", "xori": "001110", "jalr": "000000"
+      "ori": "001101", "xori": "001110", "jalr": "000000", "lb": "100000", "lbu": "100100", 
+      "lh": "100001", "lhu": "100101", "sb": "101000", "sh": "101001"   
     };
     return opcodeMap[opcodeName] || 'unknown';
   }
@@ -87,8 +88,8 @@ export class TranslatorService {
       const rt = regMap[parts[2]];
       if (!rs || !rt) return "Invalid Registers";
       binaryInstruction += rs + rt + "00000" + "00000" + funcMap[parts[0]];
-    } else if (["lw", "sw"].includes(parts[0])) {
-
+    } else if (["lw", "sw", "lb", "lbu", "lh", "lhu", "sb", "sh"].includes(parts[0])) {
+      
       const rt = regMap[parts[1]];
       const rs = regMap[parts[3].split(',')[0]];
       const immediate = parseInt(parts[2]);
@@ -220,7 +221,13 @@ export class TranslatorService {
       "000000": "sub", "000000": "slt", "000000": "and", "000000": "or", "000000": "jalr", "000000": "jr", "000000": "addu", "000000": "div", "000000": "divu", "000000": "mult", "000000": "multu", "000000": "nor", "000000": "sll", "000000": "sllv", "000000": "sra", "000000": "srav", "000000": "srl", "000000": "srlv", "000000": "subu", "000000": "xor",
       "001000": "addi",
       "100011": "lw",
+      "100000": "lb",  
+      "100100": "lbu", 
+      "100001": "lh",  
+      "100101": "lhu", 
       "101011": "sw",
+      "101000": "sb",  
+      "101001": "sh",
       "000100": "beq",
       "000101": "bne",
       "000111": "bgtz",
@@ -287,13 +294,13 @@ export class TranslatorService {
         }
 
 
-    } else if (["lw", "sw"].includes(opcodeMIPS)) {
+      } else if (["lw", "sw", "lb", "lbu", "lh", "lhu", "sb", "sh"].includes(opcodeMIPS)) {
         const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));
         const rs = this.convertRegisterToName(binaryInstruction.slice(11, 16));
         const offset = binaryInstruction.slice(16, 32);
         if (!rt || !rs || isNaN(parseInt(offset, 2))) return "Invalid Syntax";
         mipsInstruction += rs + " " + rt + " " + parseInt(offset, 2);
-
+        
         //Instruccion Tipo I
     } else if (["addi", "addiu", "andi", "ori", "xori"].includes(opcodeMIPS)) {
         const rt = this.convertRegisterToName(binaryInstruction.slice(6, 11));      

--- a/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
+++ b/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
@@ -129,6 +129,12 @@ export class TableInstructionService {
       case '001100':
       case '001101':
       case '001110':
+      case '100000': 
+      case '100100':
+      case '100001': 
+      case '100101': 
+      case '101000': 
+      case '101001':
         return { type: 'I', data: this.produceIInstruction(instruction) };
       case '000010':
       case '000011':
@@ -164,6 +170,10 @@ export class TableInstructionService {
         break;
       // Add cases for I-type and J-type instructions
       case 'lw':
+      case 'lb':
+      case 'lbu':
+      case 'lh':
+      case 'lhu':
         details = {
           operation: operation,
           rt: parts[1], // e.g., "$t1"
@@ -173,6 +183,8 @@ export class TableInstructionService {
         explanation = `This is an I-type instruction where ${details.rt} gets the value from memory at the address ${details.offset} offset from ${details.rs}.`;
         break;
       case 'sw':
+      case 'sb':
+      case 'sh':
         details = {
           operation: operation,
           rt: parts[1], // e.g., "$t1"


### PR DESCRIPTION
GPyP1_ 7: ProyectoParcial1 (Jhon Jimenez - Derek Perez)

Utilizando la última actualización del repositorio se agregó el soporte correcto y completo para las siguientes instrucciones de Load:
- lw
- lb
- lbu
- lh
- lhu

Y también para las siguientes instrucciones de Store:
- sw
- sb
- sh

A continuación se adjuntan las instrucciones de prueba y las capturas con el resultado que demuestran el correcto funcionamiento de traducción de las instrucciones de Mips a Hex y viceversa. Además de mostrarse correctamente la tabla donde se explica la instrucción de Mips.

Load:
lw $t0, 0($t1) → 0x8D280000

![1](https://github.com/user-attachments/assets/f824da88-41a7-42f8-9459-94406beb7f72)
![2](https://github.com/user-attachments/assets/45212da7-6545-4ea6-a281-60c06deee88d)

lb $t2, 8($t1) → 0x812A0008

![3](https://github.com/user-attachments/assets/b11f9248-5346-47c6-8634-77b75cf727c5)
![4](https://github.com/user-attachments/assets/1e431a7c-1e0c-4bf0-81b0-9923b0b918e2)

lbu $t0, 0($t2) → 0x91480000

![5](https://github.com/user-attachments/assets/92560e64-8bd2-4776-aad1-0cc31f32053d)
![6](https://github.com/user-attachments/assets/9259838a-1089-443a-ac87-aa1b713d7306)

Store:
sw $t0, 4($t1) → 0xAD280004

![7](https://github.com/user-attachments/assets/c2547997-444d-422c-ad97-08eb14c630fe)
![8](https://github.com/user-attachments/assets/aa605db7-aa78-47de-9f8d-6001babf416d)

sb $t2, 7($t1) → A12A0007

![9](https://github.com/user-attachments/assets/ef341e2f-96f5-414a-acc0-182ba2e3281b)
![10](https://github.com/user-attachments/assets/dc251074-87cd-42c4-abc8-f92e0d399a2e)

sh $t4, 0($t3) → 0xA56C0000

![11](https://github.com/user-attachments/assets/0dfa6c4b-4400-45a8-b266-497dd45026ee)
![12](https://github.com/user-attachments/assets/98e9f38c-f751-4259-b6ca-5aeb224ce853)

Closes #9 