### PR TITLE
Soportar totalidad de instrucciones aritméticas lógicas.

### DIFF
--- a/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
+++ b/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
@@ -147,6 +147,10 @@ export class TableInstructionService {
       case 'and':
       case 'or':
       case 'slt':
+      case 'addu':
+      case 'nor':
+      case 'subu':
+      case 'xor':
         // R-type instructions
         details = {
           operation: operation,
@@ -157,6 +161,66 @@ export class TableInstructionService {
           funct: this.converter.operationToFunctionCode(operation),
         };
         explanation = `This is an R-type instruction where ${details.rd} gets the result of ${details.operation} operation between ${details.rs} and ${details.rt}.`;
+        break;
+      case 'mult':
+      case 'multu':
+      case 'div':
+      case 'divu':
+        details = {
+          operation: operation,
+          rs: parts[1], // e.g., "$t2"
+          rt: parts[2], // e.g., "$t3"
+          rd: '0',
+          shamt: '0',
+          funct: this.converter.operationToFunctionCode(operation),
+        };
+        explanation = `This is an R-type instruction where the specials registers hi and lo gets the result of ${details.operation} operation between ${details.rs} and ${details.rt}.`;
+        break;
+      case 'sll':
+        details = {
+          operation: operation,
+          rs: '0', // e.g., "$t2"
+          rt: parts[2], // e.g., "$t3"
+          rd: parts[1], // e.g., "$t1"
+          shamt: parts[3],
+          funct: this.converter.operationToFunctionCode(operation),
+        };
+        explanation = `This is an R-type instruction where ${details.rt} realizes a logical shift to the left to ${details.rd} determined by ${details.shamt}.`;
+        break;
+      case 'srl':
+      case 'sra':
+        details = {
+          operation: operation,
+          rs: '0', // e.g., "$t2"
+          rt: parts[2], // e.g., "$t3"
+          rd: parts[1], // e.g., "$t1"
+          shamt: parts[3],
+          funct: this.converter.operationToFunctionCode(operation),
+        };
+        explanation = `This is an R-type instruction where ${details.rt} realizes a logical shift to the right to ${details.rd} determined by ${details.shamt}.`;
+        break;
+      case 'sllv':
+        details = {
+          operation: operation,
+          rs: parts[3], // e.g., "$t2"
+          rt: parts[2], // e.g., "$t3"
+          rd: parts[1], // e.g., "$t1"
+          shamt: '0',
+          funct: this.converter.operationToFunctionCode(operation),
+        };
+        explanation = `This is an R-type instruction where ${details.rt} realizes a logical shift to the left to ${details.rd} determined by ${details.rs}.`;
+        break;
+      case 'srav':
+      case 'srlv':
+        details = {
+          operation: operation,
+          rs: parts[3], // e.g., "$t2"
+          rt: parts[2], // e.g., "$t3"
+          rd: parts[1], // e.g., "$t1"
+          shamt: '0',
+          funct: this.converter.operationToFunctionCode(operation),
+        };
+        explanation = `This is an R-type instruction where ${details.rt} realizes a logical shift to the right to ${details.rd} determined by ${details.rs}.`;
         break;
       // Add cases for I-type and J-type instructions
       case 'lw':
@@ -178,6 +242,10 @@ export class TableInstructionService {
         explanation = `This is an I-type instruction where the value in ${details.rt} is stored in memory at the address ${details.offset} offset from ${details.rs}.`;
         break;
       case 'addi':
+      case 'addiu':
+      case 'andi':
+      case 'ori':
+      case 'xori':
         details = {
           operation: operation,
           rt: parts[1], // e.g., "$t1"

--- a/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
+++ b/app/src/app/Shared/Services/tableInstruction/table-instruction.service.ts
@@ -118,13 +118,17 @@ export class TableInstructionService {
     switch (opCode) {
       case '000000':
         return { type: 'R', data: this.produceRInstruction(instruction) };
-      case '001000':
-      case '100011':
-      case '101011':
-      case '000100':
-      case '000101':
-      case '000110':
-      case '000111': 
+      case '001000': // addi
+      case '001001': // addiu
+      case '001100': // andi
+      case '001101': // ori
+      case '001110': // xori
+      case '100011': // lw
+      case '101011': // sw
+      case '000100': // beq
+      case '000101': // bne
+      case '000110': // blez
+      case '000111': // bgtz
         return { type: 'I', data: this.produceIInstruction(instruction) };
       case '000010':
       case '000011':


### PR DESCRIPTION
Se han agregado las siguientes instrucciones aritméticas y lógicas al código:

- `addu`
- `addiu`
- `andi`
- `div`
- `divu`
- `mult`
- `multu`
- `nor`
- `ori`
- `sll`
- `sllv`
- `sra`
- `srav`
- `srl`
- `srlv`
- `sub`
- `subu`
- `xor`
- `xori`

Se corrigieron los errores relacionados con las instrucciones del mismo tipo pero con diferentes manejos de registros, y se eliminó el código innecesario. Además, se ajustó la tabla de detalles para mostrar todas las instrucciones actualizadas. A continuación, se presentan pruebas que demuestran su correcto funcionamiento:

![Captura desde 2024-10-20 18-55-54](https://github.com/user-attachments/assets/7bd1c2bc-26b3-400d-a6ac-036f877d0a22)

Estas instrucciones proporcionan soporte adicional para operaciones aritméticas y lógicas en el conjunto de instrucciones.
closes #7 